### PR TITLE
fix for downsize for russian

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@
 		
 		var options		= options && typeof options === "object" ? options : {},
 			wordChars	= options.wordChars instanceof RegExp ?
-								options.wordChars : /[a-z0-9\-\']/i;
+								options.wordChars : /[a-zа-я0-9\-\']/i;
 		
 		function count(chr,track) {
 			var limit = options.words || (options.characters+1) || Infinity;


### PR DESCRIPTION
downsize have a problem, that you can't downsize russian in right way (may be you need to change way from regexp to word searching, and break by words, not by characters, like 

``` javascript
string.split(/\s/).length > 200 && string.split(/\s/).slice(0, 200).join(' ').length > 1000
```

or something like that, to make it work with any language.
