### PR TITLE
handle truncating to zero words

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,12 +19,20 @@ var XRegexp = require('xregexp').XRegExp;
             tagBuffer = "",
             truncatedText = "";
 
-        var options = options && typeof options === "object" ? options : {},
+        options = options && typeof options === "object" ? options : {},
             wordChars = options.wordChars instanceof RegExp ?
                 options.wordChars : XRegexp("[\\p{L}0-9\\-\\']", "i");
 
         function count(chr, track) {
-            var limit = options.words || (options.characters + 1) || Infinity;
+            var limit;
+            if( options.words !== undefined ){
+              limit = parseInt( options.words, 10 );
+            } else if( options.characters !== undefined ){
+              limit = parseInt( options.characters , 10);
+            } else {
+              limit = Infinity;
+            }
+            limit = isNaN( limit ) ? Infinity : limit;
 
             if (!("unitCount" in track))
                 track.unitCount = 0;
@@ -34,7 +42,7 @@ var XRegexp = require('xregexp').XRegExp;
             if (!("countState" in track))
                 track.countState = !!wordChars.test(chr + "");
 
-            if (options.words) {
+            if (options.words !== undefined) {
                 if (!!wordChars.test(chr + "") !== track.countState) {
 
                     track.countState = !!wordChars.test(chr + "");

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var XRegexp = require('xregexp').XRegExp;
             tagBuffer = "",
             truncatedText = "";
 
-        options = options && typeof options === "object" ? options : {},
+        var options = options && typeof options === "object" ? options : {},
             wordChars = options.wordChars instanceof RegExp ?
                 options.wordChars : XRegexp("[\\p{L}0-9\\-\\']", "i");
 

--- a/test.js
+++ b/test.js
@@ -82,6 +82,11 @@ describe("Word-wise truncation", function () {
         downsize("<p>abcdefghij</p><p>klmnop</p><p>qrs</p>", {characters: 15})
             .should.equal("<p>abcdefghij</p><p>klmno</p>");
     });
+
+    it("should properly properly truncate to zero words", function () {
+        downsize("<p>abcdefghij</p><p>klmnop</p><p>qrs</p>", {characters: 0})
+            .should.equal("<p></p><p></p>");
+    });
 });
 
 describe("Appending", function () {


### PR DESCRIPTION
## Issue Summary

The code incorrectly handles numeric zero when truncating.  String quoted zero ("0") works.
## Steps to Reproduce

```
$ node
> downsize = require('./index.js')
[Function]
> downsize("<p>this is a <strong>test of word downsizing</strong></p>", {words: 1})
'<p>this</p>'
> downsize("<p>this is a <strong>test of word downsizing</strong></p>", {words: 0})
'<p>this is a <strong>test of word downsizing</strong></p>'
> downsize("<p>this is a <strong>test of word downsizing</strong></p>", {words: "0"})
'<p></p>'
```
## Technical Details

Downsize Version: master (latest commit: ed2d74dcb7031c3a57b43b73197e40809fa3912e)
Client OS: Mac OS X
Node Version: 0.10.12
