### PR TITLE
Fix to correctly parse single quotes found in a double quote strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,11 @@ var XRegexp = require('xregexp').XRegExp;
                     if (parseState === PARSER_TAG_STRING) {
                         parseState = PARSER_TAG_COMMENCED;
 
-                    } else if (parseState !== PARSER_UNINITIALISED) {
+                    } else if (parseState === PARSER_TAG_STRING_SINGLE) {
+                        // if double quote is found in a single quote string, ignore it and let the string finish
+                        break;
+                    }
+                    else if (parseState !== PARSER_UNINITIALISED) {
                         parseState = PARSER_TAG_STRING;
                     }
 
@@ -112,6 +116,9 @@ var XRegexp = require('xregexp').XRegExp;
                     if (parseState === PARSER_TAG_STRING_SINGLE) {
                         parseState = PARSER_TAG_COMMENCED;
 
+                    } else if (parseState === PARSER_TAG_STRING) {
+                        // if single quote is found in a double quote string, ignore it and let the string finish
+                        break;
                     } else if (parseState !== PARSER_UNINITIALISED) {
                         parseState = PARSER_TAG_STRING_SINGLE;
                     }

--- a/test.js
+++ b/test.js
@@ -10,6 +10,11 @@ describe("Word-wise truncation", function () {
             .should.equal("<p>this is a <strong>test of</strong></p>");
     });
 
+    it("should be able to truncate even if a single quote is found inside a string of double quotes or vice-versa", function () {
+        downsize('<p><img src="/someUrl.jpg" alt="Let\'s get in!"></p><p>hello world</p>', { words: 1 })
+            .should.equal('<p><img src="/someUrl.jpg" alt="Let\'s get in!"></p><p>hello</p>');
+    });
+
     it("should be able to naively balance HTML markup", function () {
         downsize("<p><p><p><p>this is a <strong>test of word downsizing</strong> some stuff</p>", {words: 5})
             .should.equal("<p><p><p><p>this is a <strong>test of</strong></p></p></p></p>");


### PR DESCRIPTION
### Issue Summary

Tags with single quotes inside double quotes doesn't get parsed/truncated correctly according to the limit (by words/characters)
### Steps to Reproduce

`ddownsize('<p><img src="/someUrl.jpg" alt="Let\'s get in!"></p><p>hello world</p>', {words:"1"});`
results to:
`'<p><img src="/someUrl.jpg" alt="Let\'s get in!"></p><p>hello world</p></p>'`

But it should result to:
`'<p><img src="/someUrl.jpg" alt="Let's get in!"></p><p>hello</p>'`

This is a bug because the specified number of html words should be followed even if the alt text of the <img> has a single quote/apostrophe.
### Technical details
- Client OS: Windows 8
- Server OS: Windows 8
- Node Version: v0.10.24
- Browser: Chrome

directly related to: https://github.com/TryGhost/Ghost/issues/2106
