### PR TITLE
Allow for 'contextual' tags which are not clipped.

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,11 +20,16 @@ var XRegexp = require('xregexp').XRegExp;
             truncatedText = "";
 
         var options = options && typeof options === "object" ? options : {},
+            keepContext = !!options.contextualTags,
+            contextualTags = keepContext && Array.isArray(options.contextualTags) ? options.contextualTags : [],
             wordChars = options.wordChars instanceof RegExp ?
                 options.wordChars : XRegexp("[\\p{L}0-9\\-\\']", "i");
 
         function count(chr, track) {
-            var limit = options.words || (options.characters + 1) || Infinity;
+            var limit = options.words || (options.characters + 1) || Infinity,
+                contextualTagPresent = false,
+                i,
+                j;
 
             if (!("unitCount" in track))
                 track.unitCount = 0;
@@ -54,7 +59,22 @@ var XRegexp = require('xregexp').XRegExp;
             }
 
             // Return true when we've hit our limit
-            return (track.unitCount >= limit);
+            if (track.unitCount < limit) {
+                return false;
+            } else {
+                if (!keepContext) {
+                    return true;
+                }
+                for (i = 0; i < contextualTags.length; i++) {
+                    for (j = 0; j < stack.length; j++) {
+                        if (contextualTags[i] === getTagName(stack[j])){
+                            return false;
+                        }
+                    }
+                }
+                // There are no contextual tags left, we can stop.
+                return true;
+            }
         }
 
         // Define our parse states

--- a/test.js
+++ b/test.js
@@ -87,6 +87,17 @@ describe("Word-wise truncation", function () {
         downsize("<p>abcdefghij</p><p>klmnop</p><p>qrs</p>", {characters: 15})
             .should.equal("<p>abcdefghij</p><p>klmno</p>");
     });
+
+    it("should await the end of the containing paragraph", function () {
+        downsize("<p>there are more than seven words in this paragraph</p><p>this is unrelated</p>", {words: 7, contextualTags: ["p", "ul", "ol", "pre", "blockquote"]})
+            .should.equal("<p>there are more than seven words in this paragraph</p>");
+    });
+
+    it("should await the end of the containing unordered list", function () {
+        downsize("<ul><li>item one</li><li>item two</li><li>item three</li></ul><p>paragraph</p>", {characters: 20, contextualTags: ["p", "ul", "ol", "pre", "blockquote"]})
+            .should.equal("<ul><li>item one</li><li>item two</li><li>item three</li></ul>");
+    });
+
 });
 
 describe("Appending", function () {
@@ -114,7 +125,7 @@ describe("Performance", function () {
         it("benchmark time should be under twenty seconds", function () {
             var startTime = Date.now();
             for (i = 0; i < 100000; i++) {
-                downsize(perfTestSeed, {"words": 5});
+                downsize(perfTestSeed, {"words": 5, contextualTags: ["p", "ul", "ol", "pre", "blockquote"]});
             }
             (Date.now() - startTime).should.be.lte(20*1000);
         });


### PR DESCRIPTION
Christopher,

This is the commit i most want to land in the project.

The motivation is to modify Downsize to output nicer blog snippets in Ghost.

The idea is to allow the user to specify a list of tags whose content should not be cleaved.
I believe this can be especially useful in allowing you to specify the core markdown top block elements ["p", "ul", "ol", "pre", "blockquote"] that have intra-article-level semantic meaning and NOT specify tags used for layout that don't covey any context (div etc.) or tags that convey context at a high level (article, header etc).

The implementation is a simple set intersection of the open tag stack and the passed list of 'contextual tags'.  

I'd love to gauge your interest in this feature! If you're not opposed, please let me know if there's anything you'd like improved in the implementation!

The test won't pass without https://github.com/cgiffard/Downsize/pull/9. (If you do want to use all the commits I've thrown at you, you can also just merge my master branch and save the conflict annoyance.)

-adam
