### PR TITLE
Allow for appending on strings without HTML

### DIFF
--- a/index.js
+++ b/index.js
@@ -244,7 +244,7 @@ var XRegexp = require('xregexp').XRegExp;
         // TODO: what should the whitespace behavior be?
         truncatedText = truncatedText.trim();
 
-        if (options.append && (stack.length || tagBuffer.length)) {
+        if (options.append && isAtLimit()) {
             truncatedText += options.append;
         }
 

--- a/test.js
+++ b/test.js
@@ -154,6 +154,16 @@ describe("Appending", function () {
             .should.equal("<p>here's some text.</p>");
     });
 
+    it("should append an ellipsis for word truncation without HTML", function () {
+        downsize("here's some text.", {words: 2, append: "..."})
+            .should.equal("here's some...");
+    });
+
+    it("should append an ellipsis for character truncation without HTML", function () {
+        downsize("here's some text.", {characters: 6, append: "..."})
+            .should.equal("here's...");
+    });
+
     it("should not have trailing empty tags", function () {
         downsize("<p>characters</p><i>what</i>", {characters: 10})
             .should.equal("<p>characters</p>");


### PR DESCRIPTION
Currently, calling `downsize("A string without HTML", {words: 2,
append: '...'}` returns `A string`.

I changed `(stack.length || tagBuffer.length)` to `isAtLimit()`, which
solves this issue and makes that line a little more clear.

Tests included.
