### PR TITLE
Add support for rounding to end of sentence

### DIFF
--- a/test.js
+++ b/test.js
@@ -161,6 +161,33 @@ describe("Appending", function () {
 
 });
 
+describe("Rounding", function () {
+    it("should round a sentence up", function () {
+        downsize("<p>abcdefghij</p><p>klmnop</p><p>qrs</p>", {characters: 15, round: true})
+            .should.equal("<p>abcdefghij</p><p>klmnop</p>");
+    });
+
+    it("should handle sentences shorter than required", function () {
+        downsize("<p>here's some text.</p>", {words: 5, round: true})
+            .should.equal("<p>here's some text.</p>");
+    });
+
+    it("should round up to end of sentence, not just next tag", function () {
+        downsize("<p>here's <em>some</em> text.</p>", {characters: 2, round: true})
+            .should.equal("<p>here's <em>some</em> text.</p>");
+    });
+
+    it("should not have trailing empty tags", function () {
+        downsize("<p>characters</p><i>what</i>", {characters: 10, round: true})
+            .should.equal("<p>characters</p>");
+    });
+
+    it("should scoop up to end of text if no closing paragraph found", function () {
+        downsize("<p>characters</p><i>what</i>", {characters: 11, round: true})
+            .should.equal("<p>characters</p><i>what</i>");
+    });
+});
+
 describe("Performance", function () {
     var perfTestSeed = "";
     for (var i = 0; i < 1000000; i++) {


### PR DESCRIPTION
Use: 

``` js
downsize("<p>My super long sentence that I don't want chomped.</p><p>But I would like around 75 characters on the page, but I don't want to cut halfway through a sentence.</p>", {
  characters: 75, 
  round: true
}); // result: original two <p> tags
```

Also includes initial tests (all passing) (could do with more?)

If options.round is used, then as the text is parsed, if it hits the character limit, it also checks to see if it's at the edge of a closing sentence tag . If not, it'll continue to scoop up the text.

If the parser reaches a `PARSER_TAG_COMMENCED` character (`<`), then it peeks at the upcoming HTML, and checks if that tag would suggest the end of a sentence, i.e. a `</p>`, `</div>`, `</li>`, etc.

Note: I also tested that it works correctly with unclosed `<p>` tags, which it does, but the current version of Downsize tries to close all tracked open tags (so if there's more than one automatic closing `<p>` tag), they're all slapped on the end of the string, resulting in: `<p>foo<p>bar</p></p>` - this is a completely separate bug which may or may not be worth dealing with.
